### PR TITLE
two new methods of a page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
+## 1.0.0.beta4  - 2018/03/27
+
+* [FEATURE] Add `Fb::Page#insights_with_date_range` and `Fb::Page#posts_with_time_range`.
+
 ## 1.0.0.beta3  - 2018/03/14
 
 * [FEATURE] Add `video_avg_time_watched` to `Fb::Post` for length of average time watched.

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ metric, period, and options (since & until). Refer to
 for a list of available metrics and periods.
 
 **Ensure that the period that you are using is supported by the metric**.
-For example, `page_views_total` (page views) is available for `week`, `week`, and `days_28`
+For example, `page_views_total` (page views) is available for `day`, `week`, and `days_28`
 whereas `page_fans` (page likes) is only available as `lifetime`.
 
 `metric_insights` returns a hash of Dates mapped to values. Passing `since` only return dates ahead

--- a/fb-core.gemspec
+++ b/fb-core.gemspec
@@ -24,10 +24,10 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'fb-support', '~> 1.0.0.alpha1'
+  spec.add_dependency 'fb-support', '~> 1.0.0.alpha4'
   spec.add_development_dependency 'bundler', '~> 1.15'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
-  spec.add_development_dependency 'yard', '~> 0.9.9'
+  spec.add_development_dependency 'yard', '~> 0.9.12'
   spec.add_development_dependency 'coveralls'
 end

--- a/lib/fb/core/version.rb
+++ b/lib/fb/core/version.rb
@@ -3,6 +3,6 @@ module Fb
   class Core
     # @return [String] the SemVer-compatible gem version.
     # @see http://semver.org
-    VERSION = '1.0.0.beta3'
+    VERSION = '1.0.0.beta4'
   end
 end

--- a/spec/page/insights_with_date_range_spec.rb
+++ b/spec/page/insights_with_date_range_spec.rb
@@ -1,0 +1,25 @@
+RSpec.describe 'Fb::Page#insights_with_date_range' do
+  let(:user) { Fb::User.new access_token: ENV['FB_TEST_ACCESS_TOKEN'] }
+  let(:page) { user.pages.first  }
+
+  context 'given a page and valid metrics' do
+    let(:metrics) { %i(page_impressions page_impressions_paid) }
+
+    it 'returns a hash of given metrics mapped to their values' do
+      days_of_insights = page.insights_with_date_range metrics, since: Date.today - 21, until: Date.today
+      expect(days_of_insights).to be_a(Hash)
+      expect(days_of_insights.keys).to match_array metrics
+      expect(days_of_insights.values).to all (be_an Integer)
+    end
+  end
+
+  context 'given a page and invalid metrics' do
+    let(:metrics) { %i(invalid_metric) }
+
+    it 'raises an HTTPError' do
+      expect do
+        page.insights_with_date_range metrics, since: Date.today - 12, until: Date.today
+      end.to raise_error Fb::HTTPError
+    end
+  end
+end

--- a/spec/page/posts_with_time_range_spec.rb
+++ b/spec/page/posts_with_time_range_spec.rb
@@ -1,0 +1,40 @@
+RSpec.describe 'Fb::Page#posts_with_time_range' do
+  let(:user) { Fb::User.new access_token: ENV['FB_TEST_ACCESS_TOKEN'] }
+  let(:page) { user.pages.first }
+  let(:options) {{
+    since: Time.parse((Date.today - 7).to_s),
+    until: Time.parse((Date.today + 1).to_s)
+  }}
+
+  context 'given a valid access token' do
+    it 'returns array of Post for any given page' do
+      days_of_posts = page.posts_with_time_range(options)
+      expect(days_of_posts).to be_a(Array)
+      expect(days_of_posts).to all (be_a Fb::Post)
+      expect(days_of_posts.map &:id).to all(be_a String)
+      expect(days_of_posts.map &:type).to all(be_a String)
+      expect(days_of_posts.map &:url).to all(be_a String)
+      expect(days_of_posts.map &:type).to all(be_a String)
+      expect(days_of_posts.map &:created_at).to all(be_a Time)
+      expect(days_of_posts.map &:length).to all(be_a String)
+
+      expect(days_of_posts.map &:share_count).to all(be_a Integer)
+      expect(days_of_posts.map &:comment_count).to all(be_a Integer)
+      expect(days_of_posts.map &:like_count).to all(be_a Integer)
+      expect(days_of_posts.map &:reaction_count).to all(be_a Integer)
+
+      expect(days_of_posts.map &:created_at).to all (be >= options[:since])
+      expect(days_of_posts.map &:created_at).to all (be <= options[:until])
+    end
+  end
+
+  context 'given with_metrics' do
+    it 'returns an array of posts with metrics' do
+      days_of_video_posts = page.posts_with_time_range(options.merge with_metrics: true).select{|post| post.type == 'video'}
+      expect(days_of_video_posts.map &:video_views).to all (be_an Integer)
+      expect(days_of_video_posts.map &:video_views_organic).to all (be_an Integer)
+      expect(days_of_video_posts.map &:video_views_paid).to all (be_an Integer)
+      expect(days_of_video_posts.map &:video_view_time).to all (be_an Integer)
+    end
+  end
+end


### PR DESCRIPTION
Add `Page#insights_with_date_range` method and `Page#posts_with_time_range` method
+ posts_with_time_range: basically same with `posts` method but without memoization, so you can get different result by calling more than two times
+ insights_with_date_range: it is similar with weekly_insights but it's adding all the daily insights of arbitrary date range. So if you `insights_with_date_range(since: Jan 1, until: Jan 31)` to get January data for example.