### PR TITLE
Return nil for empty value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
+## 1.0.0.beta7  - 2018/04/09
+
+**How to upgrade**
+
+If your code is expecting `Page#weekly_insights` method to return `0` value
+when response is empty, now it returns `nil`. This is a breaking change.
+
+* [IMPROVEMENT] Return `nil` for empty metric value in `weekly_insights`.
+
 ## 1.0.0.beta6  - 2018/04/05
 
 * [FEATURE] Add `backdated_time`, `total_impressions`, `total_impressions_unique`,

--- a/lib/fb/core/version.rb
+++ b/lib/fb/core/version.rb
@@ -3,6 +3,6 @@ module Fb
   class Core
     # @return [String] the SemVer-compatible gem version.
     # @see http://semver.org
-    VERSION = '1.0.0.beta6'
+    VERSION = '1.0.0.beta7'
   end
 end

--- a/lib/fb/page.rb
+++ b/lib/fb/page.rb
@@ -43,7 +43,7 @@ module Fb
       since_date = options.fetch :until, Date.today - 1
       params = {period: :week, since: since_date, until: since_date + 2}
       insights = page_insights Array(metrics), params
-      insights.map {|m| [m['name'].to_sym, m['values'].last.fetch('value', 0)]}.to_h
+      insights.map {|m| [m['name'].to_sym, m['values'].last.fetch('value', nil)]}.to_h
     end
 
     # @return [Integer] the number of views of the page.

--- a/lib/fb/post.rb
+++ b/lib/fb/post.rb
@@ -80,13 +80,13 @@ module Fb
       @length = options.fetch(:properties, []).find(-> { {'text' => 'n/a'} }) do |property|
         property['name'] == 'Length'
       end['text']
-      @engaged_users = options[:post_engaged_users] if options[:post_engaged_users]
-      @video_views = options[:post_video_views] if options[:post_video_views]
-      @video_views_organic = options[:post_video_views_organic] if options[:post_video_views_organic]
-      @video_views_paid = options[:post_video_views_paid] if options[:post_video_views_paid]
-      @video_view_time = options[:post_video_view_time] if options[:post_video_view_time]
-      @impressions = options[:post_impressions] if options[:post_impressions]
-      @video_avg_time_watched = options[:post_video_avg_time_watched] if options[:post_video_avg_time_watched]
+      @engaged_users = options[:post_engaged_users]
+      @video_views = options[:post_video_views]
+      @video_views_organic = options[:post_video_views_organic]
+      @video_views_paid = options[:post_video_views_paid]
+      @video_view_time = options[:post_video_view_time]
+      @impressions = options[:post_impressions]
+      @video_avg_time_watched = options[:post_video_avg_time_watched]
 
       @share_count = options[:shares] ? options[:shares]["count"] : 0
       @comment_count = options[:comments]['summary']['total_count'] if options[:comments]


### PR DESCRIPTION
Facebook respond with nothing when there's no data available (yet). In that case, returning 0 value can be confusing because the value can be really a 0. Sometimes the expecting return value is a Hash, not an integer.
