### PR TITLE
sometimes a video does not need all the metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
+
+## 1.0.0.beta9  - 2018/04/20
+
+* [FEATURE] Add `:without_lifetime_metrics` option to `Page#videos` method .
+
 ## 1.0.0.beta8  - 2018/04/20
 
 * [FEATURE] Add `consumptions`, `engaged_fan`, `fan_reach` and many more metrics to `Fb::Post`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,7 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
-
-## 1.0.0.beta9  - 2018/04/20
+## 1.0.0.beta9  - 2018/04/25
 
 * [FEATURE] Add `:without_lifetime_metrics` option to `Page#videos` method .
 

--- a/lib/fb/core/version.rb
+++ b/lib/fb/core/version.rb
@@ -3,6 +3,6 @@ module Fb
   class Core
     # @return [String] the SemVer-compatible gem version.
     # @see http://semver.org
-    VERSION = '1.0.0.beta8'
+    VERSION = '1.0.0.beta9'
   end
 end

--- a/lib/fb/page.rb
+++ b/lib/fb/page.rb
@@ -89,11 +89,11 @@ module Fb
     end
 
     # @return [Array<Fb::Video>] the uploaded videos for the page.
-    def videos
+    def videos(options = {})
       @videos ||= begin
         request = PaginatedRequest.new path: "/v2.9/#{@id}/videos", params: video_params
         data = request.run.body['data']
-        videos_with_metrics_from(data)
+        options[:without_lifetime_metrics] ? videos_from(data) : videos_with_metrics_from(data)
       end
     end
 
@@ -183,6 +183,12 @@ module Fb
           end.to_h
           Video.new symbolize_keys video_data.merge(insights_data)
         end
+      end
+    end
+
+    def videos_from(data)
+      data.map do |video_data|
+        Video.new symbolize_keys video_data
       end
     end
 

--- a/lib/fb/post.rb
+++ b/lib/fb/post.rb
@@ -6,6 +6,7 @@ module Fb
   #   video_views, video_views_organic, video_views_paid, and so on.
   # @see https://developers.facebook.com/docs/graph-api/reference/v2.10/post
   class Post
+    attr_accessor :custom_labels
 
     # @option [String] the post’s unique ID.
     attr_reader :id

--- a/spec/page/videos_spec.rb
+++ b/spec/page/videos_spec.rb
@@ -25,4 +25,11 @@ RSpec.describe 'Fb::Page#videos' do
       # expect(page.videos.map &:total_views_sound_on).to all (be_an Integer)
     end
   end
+
+  context 'given without_lifetime_metrics' do
+    it 'returns an array of videos without metrics' do
+      expect(page.videos(without_lifetime_metrics: true).map &:id).to all (be_an String)
+      expect(page.videos).to be_a(Array)
+    end
+  end
 end

--- a/spec/post/custom_labels_spec.rb
+++ b/spec/post/custom_labels_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+
+RSpec.describe 'Fb::Post#custom_labels=' do
+  context 'given a video post' do
+    let(:post) { Fb::Post.new type: 'video', created_time: '2008-08-08T08:00:00+0000' }
+
+    it 'sets and gets custom_labels value' do
+      post.custom_labels = ["Kids Play"]
+      expect(post.custom_labels).to eq ["Kids Play"]
+    end
+  end
+end

--- a/spec/post/length_spec.rb
+++ b/spec/post/length_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'Fb::Post#length' do
     end
   end
 
-  context 'given a video post with a length property' do
+  context 'given a video post without a length property' do
     let(:post) { Fb::Post.new type: 'video', created_time: '2008-08-08T08:00:00+0000' }
     it 'returns length as n/a' do
       expect(post.length).to eq 'n/a'


### PR DESCRIPTION
It is similar to adding `:with_metrics` option of `posts` method but opposite direction. In order not to break compatibility, I came to an idea of adding `:without_lifetime_metrics` option for `videos` method.