### PR TITLE
For created_at of a post, Use UTC time as Facebook created_time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
+
+## 1.0.0 - Unreleased
+
+* [IMPROVEMENT] Return UTC time for String value of `created_time`, `backdated_time`,
+`end_time`, etc from Facebook to have exact time.
+
 ## 1.0.0.beta10  - 2018/05/01
 
 * [FEATURE] Add `:since` and `:until` option to `Page#videos` method.

--- a/lib/fb/page.rb
+++ b/lib/fb/page.rb
@@ -70,10 +70,11 @@ module Fb
     # @option [Boolean] :with_metrics whether to include insights for the posts.
     def posts(options = {})
       @posts ||= begin
+        with_metrics = options.delete :with_metrics
         params = posts_params.merge options
         request = PaginatedRequest.new path: "/v2.9/#{@id}/posts", params: params
         data = request.run.body['data']
-        options[:with_metrics] ? posts_with_metrics_from(data) : posts_from(data)
+        with_metrics ? posts_with_metrics_from(data) : posts_from(data)
       end
     end
 
@@ -95,10 +96,11 @@ module Fb
     # @option [Boolean] :without_lifetime_metrics whether to include insights for the videos.
     def videos(options = {})
       @videos ||= begin
+        without_lifetime_metrics = options.delete :without_lifetime_metrics
         params = video_params.merge options
         request = PaginatedRequest.new path: "/v2.9/#{@id}/videos", params: params
         data = request.run.body['data']
-        options[:without_lifetime_metrics] ? videos_from(data) : videos_with_metrics_from(data)
+        without_lifetime_metrics ? videos_from(data) : videos_with_metrics_from(data)
       end
     end
 

--- a/lib/fb/page.rb
+++ b/lib/fb/page.rb
@@ -32,7 +32,7 @@ module Fb
       insights = page_insights Array(metric), options.merge(period: period)
       values = insights.find{|data| data['name'] == metric}['values']
       values.map do |v|
-        [Date.strptime(v['end_time'], '%Y-%m-%dT%H:%M:%S+0000'), v.fetch('value', 0)]
+        [Date.parse(v['end_time']), v.fetch('value', 0)]
       end.to_h
     end
 

--- a/lib/fb/post.rb
+++ b/lib/fb/post.rb
@@ -236,7 +236,7 @@ module Fb
     def initialize(options = {})
       @id = options[:id]
       @url = options[:permalink_url]
-      @created_at = Time.strptime(options[:created_time], '%Y-%m-%dT%H:%M:%S+0000')
+      @created_at = Time.parse options[:created_time]
       @type = options[:type]
       @message = options[:message]
       @length = options.fetch(:properties, []).find(-> { {'text' => 'n/a'} }) do |property|

--- a/lib/fb/video.rb
+++ b/lib/fb/video.rb
@@ -97,8 +97,8 @@ module Fb
       @content_tags = options[:content_tags] ? Array(options[:content_tags]) : []
       @ad_breaks = options[:ad_breaks] ? Array(options[:ad_breaks]) : []
       @length = options[:length]
-      @created_at = Time.strptime(options[:created_time], '%Y-%m-%dT%H:%M:%S+0000') if options[:created_time]
-      @backdated_time = Time.strptime(options[:backdated_time], '%Y-%m-%dT%H:%M:%S+0000') if options[:backdated_time]
+      @created_at = Time.parse(options[:created_time]) if options[:created_time]
+      @backdated_time = Time.parse(options[:backdated_time]) if options[:backdated_time]
 
       @total_views = options[:total_video_views]
       @total_views_unique = options[:total_video_views_unique]


### PR DESCRIPTION
in the Facebook response

```rb
created_time = "2018-04-13T15:00:01+0000" 
```
but current way with `strptime` it parses into a local time, that is not exact
```rb
require 'time'
# => true
Time.strptime(created_time,  '%Y-%m-%dT%H:%M:%S+0000')
# => 2018-04-13 15:00:01 -0700
Time.parse created_time
# => 2018-04-13 15:00:01 +0000
```