### PR TITLE
require standard libraries "time" and "date"

### DIFF
--- a/lib/fb/core.rb
+++ b/lib/fb/core.rb
@@ -5,6 +5,7 @@ require 'fb/page'
 require 'fb/user'
 require 'fb/post'
 require 'fb/video'
+
 # An object-oriented Ruby client for the Facebook Graph API.
 # @see http://www.rubydoc.info/gems/fb-core/
 module Fb

--- a/lib/fb/page.rb
+++ b/lib/fb/page.rb
@@ -1,3 +1,5 @@
+require 'date'
+
 module Fb
   # Provides methods to interact with Facebook pages through the Graph API.
   # @see https://developers.facebook.com/docs/graph-api/reference/page/

--- a/lib/fb/post.rb
+++ b/lib/fb/post.rb
@@ -236,7 +236,7 @@ module Fb
     def initialize(options = {})
       @id = options[:id]
       @url = options[:permalink_url]
-      @created_at = Time.parse options[:created_time]
+      @created_at = Time.parse(options[:created_time]) if options[:created_time]
       @type = options[:type]
       @message = options[:message]
       @length = options.fetch(:properties, []).find(-> { {'text' => 'n/a'} }) do |property|

--- a/lib/fb/post.rb
+++ b/lib/fb/post.rb
@@ -1,5 +1,5 @@
-# Ruby client to authenticate a Facebook user.
-# @see http://www.rubydoc.info/gems/Fb/
+require 'time'
+
 module Fb
   # Fb::Post reprensents a Facebook post. Post provides getters for:
   #   :id, :url, :created_at, :type, :message, :length, engaged_users,

--- a/lib/fb/video.rb
+++ b/lib/fb/video.rb
@@ -1,3 +1,5 @@
+require 'time'
+
 module Fb
   # Fb::Video represents a Facebook video. Fb::Video provides getter methods.
   # @see https://developers.facebook.com/docs/graph-api/reference/video/


### PR DESCRIPTION
We have been using fb-core from Rails apps, so did not realize the `Time` and `Date` classes were given. By this change, this gem can be used from Ruby scripts in general.