### PR TITLE
lifetime_insights method to get metrics by each post

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ For more information about changelogs, check
 
 * [IMPROVEMENT] Return UTC time for String value of `created_time`, `backdated_time`,
 `end_time`, etc from Facebook to have exact time.
+* [FEATURE] Add Fb::Post#lifetime_insights` method to get metrics of each post.
 
 ## 1.0.0.beta10  - 2018/05/01
 

--- a/lib/fb/page.rb
+++ b/lib/fb/page.rb
@@ -13,6 +13,8 @@ module Fb
     # @option [String] the page’s category.
     attr_reader :category
 
+    attr_reader :access_token
+
     # @param [Hash] options to initialize a Page object.
     # @option [String] :id The page’s unique ID.
     # @option [String] :name The page’s name.

--- a/lib/fb/post.rb
+++ b/lib/fb/post.rb
@@ -300,6 +300,9 @@ module Fb
       @video_view_time_organic = options[:post_video_view_time_organic]
     end
 
+    # @return [Hash] a hash of metrics mapped to their values.
+    # @param [Array<String, Symbol>] :metrics the metrics to fetch.
+    # @param [String] :page_access_token page access token of its page.
     def lifetime_insights(metrics, page_access_token)
       params = { metric: Array(metrics).join(","), access_token: page_access_token, period: "lifetime", ids: id }
       request = HTTPRequest.new path: "/v2.9/insights", params: params

--- a/lib/fb/post.rb
+++ b/lib/fb/post.rb
@@ -5,7 +5,7 @@ module Fb
   #   :id, :url, :created_at, :type, :message, :length, engaged_users,
   #   video_views, video_views_organic, video_views_paid, and so on.
   # @see https://developers.facebook.com/docs/graph-api/reference/v2.10/post
-  class Post
+  class Post < Resource
     attr_accessor :custom_labels
 
     # @option [String] the post’s unique ID.
@@ -298,6 +298,17 @@ module Fb
       @video_views_sound_on = options[:post_video_views_sound_on]
       @video_view_time = options[:post_video_view_time]
       @video_view_time_organic = options[:post_video_view_time_organic]
+    end
+
+    def lifetime_insights(metrics, page_access_token)
+      params = { metric: Array(metrics).join(","), access_token: page_access_token, period: "lifetime", ids: id }
+      request = HTTPRequest.new path: "/v2.9/insights", params: params
+      insights = request.run.body
+
+      data = insights[id]['data'].map do |metric|
+        [metric['name'], metric['values'].last.fetch('value', 0)]
+      end.to_h
+      symbolize_keys data
     end
 
     # @return [String] the representation of the post.

--- a/spec/post/lifetime_insights_spec.rb
+++ b/spec/post/lifetime_insights_spec.rb
@@ -3,11 +3,7 @@ require 'spec_helper'
 RSpec.describe 'Fb::Post#lifetime_insights' do
   let(:user) { Fb::User.new access_token: ENV['FB_TEST_ACCESS_TOKEN'] }
   let(:page) { user.pages.first }
-  let(:options) {{
-    since: Time.parse((Date.today - 7).to_s),
-    until: Time.parse((Date.today + 1).to_s)
-  }}
-  let(:post) { page.posts(options).first }
+  let(:post) { page.posts.first }
 
   context 'given a post and valid metrics' do
     let(:metrics) { %i(post_video_views post_video_view_time) }

--- a/spec/post/lifetime_insights_spec.rb
+++ b/spec/post/lifetime_insights_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+RSpec.describe 'Fb::Post#lifetime_insights' do
+  let(:user) { Fb::User.new access_token: ENV['FB_TEST_ACCESS_TOKEN'] }
+  let(:page) { user.pages.first }
+  let(:options) {{
+    since: Time.parse((Date.today - 7).to_s),
+    until: Time.parse((Date.today + 1).to_s)
+  }}
+  let(:post) { page.posts(options).first }
+
+  context 'given a post and valid metrics' do
+    let(:metrics) { %i(post_video_views post_video_view_time) }
+
+    it 'returns a hash of given metrics mapped to their values' do
+      lifetime_insights = post.lifetime_insights metrics, page.access_token
+      expect(lifetime_insights).to be_a(Hash)
+      expect(lifetime_insights.keys).to match_array metrics
+      expect(lifetime_insights.values).to all (be_an Integer)
+    end
+  end
+
+  context 'given a page and invalid metrics' do
+    let(:metrics) { %i(invalid_metric) }
+
+    it 'raises an HTTPError' do
+      expect{post.lifetime_insights metrics, page.access_token}.to raise_error Fb::HTTPError
+    end
+  end
+end


### PR DESCRIPTION
`Fb::Post#lifetime_insights` method will be a good addition because when calling Fb::Page#posts with `with_metrics: true` it makes too big requests (it could be a reason to get "error code 1") to get all the metrics of all the posts, but it can be small requests (but many) if we calling metrics of posts post by post. There seems no error flag or sign of exceeding quota limit because of too many requests, has not been found yet