### PR TITLE
Return empty hash when a metric returns empty array

### DIFF
--- a/lib/fb/page.rb
+++ b/lib/fb/page.rb
@@ -34,7 +34,8 @@ module Fb
     # @option [Date] :until only return dates previous to this day (upper bound).
     def metric_insights(metric, period, options = {})
       insights = page_insights Array(metric), options.merge(period: period)
-      values = insights.find{|data| data['name'] == metric}['values']
+      return {} if insights.empty?
+      values = insights.find(->{{}}){|data| data['name'] == metric}['values']
       values.map do |v|
         [Date.parse(v['end_time']), v.fetch('value', 0)]
       end.to_h


### PR DESCRIPTION
Sometimes I experience edge cases, once I found we received an empty array for `page_fans_gender_age` metric when fetch it from a small and new Facebook page. And current code returns `nil` in that case, that's probably not what we want.